### PR TITLE
Fix always update inheritance_sources in DNS Auth zone

### DIFF
--- a/b1ddi/data_source_dns_auth_zone.go
+++ b/b1ddi/data_source_dns_auth_zone.go
@@ -39,8 +39,11 @@ func dataSourceConfigAuthZoneRead(ctx context.Context, d *schema.ResourceData, m
 	filtersMap := d.Get("filters").(map[string]interface{})
 	filterStr := filterFromMap(filtersMap)
 
+	is := "partial"
+
 	resp, err := c.DNSConfigurationAPI.AuthZone.AuthZoneList(&auth_zone.AuthZoneListParams{
 		Filter:  swag.String(filterStr),
+		Inherit: &is,
 		Context: ctx,
 	}, nil)
 	if err != nil {

--- a/b1ddi/resource_dns_auth_zone.go
+++ b/b1ddi/resource_dns_auth_zone.go
@@ -101,11 +101,10 @@ func resourceConfigAuthZone() *schema.Resource {
 
 			// Optional. Inheritance configuration.
 			"inheritance_sources": {
-				Type:     schema.TypeList,
-				Elem:     schemaConfigAuthZoneInheritance(),
-				MaxItems: 1,
-				Optional: true,
-				//Computed:    true,
+				Type:        schema.TypeList,
+				Elem:        schemaConfigAuthZoneInheritance(),
+				MaxItems:    1,
+				Optional:    true,
 				Description: "Optional. Inheritance configuration.",
 			},
 
@@ -638,7 +637,11 @@ func inheritanceSourceObjUpdater(d []interface{}, r *models.ConfigAuthZoneInheri
 	authZoneInheritance := new(models.ConfigAuthZoneInheritance)
 
 	for _, v := range d {
-		for key, value := range v.(map[string]interface{}) {
+		inheritanceSources, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for key, value := range inheritanceSources {
 			if reflect.ValueOf(value).Len() > 0 {
 				switch key {
 				case "gss_tsig_enabled":

--- a/b1ddi/resource_dns_auth_zone.go
+++ b/b1ddi/resource_dns_auth_zone.go
@@ -416,9 +416,11 @@ func resourceConfigAuthZoneRead(ctx context.Context, d *schema.ResourceData, m i
 	if err != nil {
 		diags = append(diags, diag.FromErr(err)...)
 	}
-	err = d.Set("inheritance_sources", flattenConfigAuthZoneInheritance(resp.Payload.Result.InheritanceSources))
-	if err != nil {
-		diags = append(diags, diag.FromErr(err)...)
+	if resp.Payload.Result.InheritanceSources != nil {
+		err = d.Set("inheritance_sources", flattenConfigAuthZoneInheritance(resp.Payload.Result.InheritanceSources))
+		if err != nil {
+			diags = append(diags, diag.FromErr(err)...)
+		}
 	}
 	err = d.Set("initial_soa_serial", resp.Payload.Result.InitialSoaSerial)
 	if err != nil {

--- a/b1ddi/schema_dns_config_auth_zone_inheritance.go
+++ b/b1ddi/schema_dns_config_auth_zone_inheritance.go
@@ -83,16 +83,31 @@ func flattenConfigAuthZoneInheritance(r *models.ConfigAuthZoneInheritance) []int
 		return []interface{}{}
 	}
 
+	m := map[string]interface{}{}
+
+	if r.GssTsigEnabled != nil {
+		m["gss_tsig_enabled"] = flattenInheritanceInheritedBool(r.GssTsigEnabled)
+	}
+	if r.Notify != nil {
+		m["notify"] = flattenInheritanceInheritedBool(r.Notify)
+	}
+	if r.QueryACL != nil {
+		m["query_acl"] = flattenConfigInheritedACLItems(r.QueryACL)
+	}
+	if r.TransferACL != nil {
+		m["transfer_acl"] = flattenConfigInheritedACLItems(r.TransferACL)
+	}
+	if r.UpdateACL != nil {
+		m["update_acl"] = flattenConfigInheritedACLItems(r.UpdateACL)
+	}
+	if r.UseForwardersForSubzones != nil {
+		m["use_forwarders_for_subzones"] = flattenInheritanceInheritedBool(r.UseForwardersForSubzones)
+	}
+	if r.ZoneAuthority != nil {
+		m["zone_authority"] = flattenConfigInheritedZoneAuthority(r.ZoneAuthority)
+	}
 	return []interface{}{
-		map[string]interface{}{
-			"gss_tsig_enabled":            flattenInheritanceInheritedBool(r.GssTsigEnabled),
-			"notify":                      flattenInheritanceInheritedBool(r.Notify),
-			"query_acl":                   flattenConfigInheritedACLItems(r.QueryACL),
-			"transfer_acl":                flattenConfigInheritedACLItems(r.TransferACL),
-			"update_acl":                  flattenConfigInheritedACLItems(r.UpdateACL),
-			"use_forwarders_for_subzones": flattenInheritanceInheritedBool(r.UseForwardersForSubzones),
-			"zone_authority":              flattenConfigInheritedZoneAuthority(r.ZoneAuthority),
-		},
+		m,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-openapi/swag v0.22.3
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
-	github.com/infobloxopen/b1ddi-go-client v0.1.1
+	github.com/infobloxopen/b1ddi-go-client v0.1.2-0.20230906164116-a93d9085f887
 	github.com/stretchr/testify v1.8.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/infobloxopen/b1ddi-go-client v0.1.1 h1:Q3hWZaFuwc6mJuL1JT9zH0BybStGHTpDTXKJ/fSMZhQ=
-github.com/infobloxopen/b1ddi-go-client v0.1.1/go.mod h1:PiVUVEyW01EDRGdYoi0kmv4Da1RpcJL12NtEjsZsN+g=
+github.com/infobloxopen/b1ddi-go-client v0.1.2-0.20230906164116-a93d9085f887 h1:xoInFEw0n4d4FFCRjR9wPiIEr4mbgKvlXfIoH9JCyL4=
+github.com/infobloxopen/b1ddi-go-client v0.1.2-0.20230906164116-a93d9085f887/go.mod h1:PiVUVEyW01EDRGdYoi0kmv4Da1RpcJL12NtEjsZsN+g=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=


### PR DESCRIPTION
# Issue/Feature description

Fix for #6 

# How it was fixed/implemented

Check if `inheritance_sources` is not nil before setting in the ResourceData

# Tests

Verified on a local cluster. Not seeing ` b1dd1_dns_auth_zone` continuously wanting to apply `inheritance_sources`

# Reviewers
@akleinib