### PR TITLE
Tags support for IPAM/DHCP objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,6 @@ install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
-install-local: build
-	rm -rf ~/.terraform.d/plugins/registry.terraform.io/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
-	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
-	mv ${BINARY} ~/.terraform.d/plugins/registry.terraform.io/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
-
 test:
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4 -coverprofile cover.out

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ install: build
 	mkdir -p ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 	mv ${BINARY} ~/.terraform.d/plugins/${HOSTNAME}/${NAMESPACE}/${NAME}/${VERSION}/${OS_ARCH}
 
+install-local: build
+	rm -rf ~/.terraform.d/plugins/registry.terraform.io/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
+	mkdir -p ~/.terraform.d/plugins/registry.terraform.io/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
+	mv ${BINARY} ~/.terraform.d/plugins/registry.terraform.io/${NAMESPACE}/${NAME}/${VERSION}/darwin_amd64
+
 test:
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4 -coverprofile cover.out

--- a/b1ddi/data_source_ipam_address_block.go
+++ b/b1ddi/data_source_ipam_address_block.go
@@ -21,6 +21,11 @@ func dataSourceIpamsvcAddressBlock() *schema.Resource {
 				Optional:    true,
 				Description: "Configure a map of filters to be applied on the search result.",
 			},
+			"tfilters": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Configure a map of tag filters to be applied on the search result.",
+			},
 			"results": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -39,8 +44,12 @@ func dataSourceIpamsvcAddressBlockRead(ctx context.Context, d *schema.ResourceDa
 	filtersMap := d.Get("filters").(map[string]interface{})
 	filterStr := filterFromMap(filtersMap)
 
+	tfiltersMap := d.Get("tfilters").(map[string]interface{})
+	tfilterStr := filterFromMap(tfiltersMap)
+
 	resp, err := c.IPAddressManagementAPI.AddressBlock.AddressBlockList(&address_block.AddressBlockListParams{
 		Filter:  swag.String(filterStr),
+		Tfilter: swag.String(tfilterStr),
 		Context: ctx,
 	}, nil)
 	if err != nil {

--- a/b1ddi/data_source_ipam_address_block_test.go
+++ b/b1ddi/data_source_ipam_address_block_test.go
@@ -27,6 +27,19 @@ func TestAccDataSourceIpamsvcAddressBlock_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.comment", "This Address Block is created by terraform provider acceptance test"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+					data "b1ddi_address_blocks" "tf_acc_address_blocks_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks_by_tag", "tfilters.TestType", "Acceptance"),
+				),
+			},
 		},
 	})
 }

--- a/b1ddi/data_source_ipam_address_block_test.go
+++ b/b1ddi/data_source_ipam_address_block_test.go
@@ -20,18 +20,11 @@ func TestAccDataSourceIpamsvcAddressBlock_Basic(t *testing.T) {
 							"name" = "tf_acc_test_address_block"
 						}
 					}
-					data "b1ddi_address_blocks" "tf_acc_address_blocks_by_tag" {
-						tfilters = {
-							# Search by Tag
-							"TestType" = "Acceptance"
-						}
-					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.comment", "This Address Block is created by terraform provider acceptance test"),
-					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},
 		},
@@ -52,11 +45,20 @@ func TestAccDataSourceIpamsvcAddressBlock_FullConfig(t *testing.T) {
 							"name" = "tf_acc_test_address_block"
 						}
 					}
+					data "b1ddi_address_blocks" "tf_acc_address_blocks_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.comment", "This Address Block is created by terraform provider acceptance test"),
+					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks_by_tag", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_address_blocks.tf_acc_address_blocks_by_tag", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks_by_tag", "results.0.tags.TestType", "Acceptance"),
 				),
 			},
 		},

--- a/b1ddi/data_source_ipam_address_block_test.go
+++ b/b1ddi/data_source_ipam_address_block_test.go
@@ -20,15 +20,6 @@ func TestAccDataSourceIpamsvcAddressBlock_Basic(t *testing.T) {
 							"name" = "tf_acc_test_address_block"
 						}
 					}
-				`),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.#", "1"),
-					resource.TestCheckResourceAttrSet("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.id"),
-					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.comment", "This Address Block is created by terraform provider acceptance test"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
 					data "b1ddi_address_blocks" "tf_acc_address_blocks_by_tag" {
 						tfilters = {
 							# Search by Tag
@@ -37,6 +28,9 @@ func TestAccDataSourceIpamsvcAddressBlock_Basic(t *testing.T) {
 					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks", "results.0.comment", "This Address Block is created by terraform provider acceptance test"),
 					resource.TestCheckResourceAttr("data.b1ddi_address_blocks.tf_acc_address_blocks_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},

--- a/b1ddi/data_source_ipam_fixed_address.go
+++ b/b1ddi/data_source_ipam_fixed_address.go
@@ -21,6 +21,11 @@ func dataSourceIpamsvcFixedAddress() *schema.Resource {
 				Optional:    true,
 				Description: "Configure a map of filters to be applied on the search result.",
 			},
+			"tfilters": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Configure a map of tag filters to be applied on the search result.",
+			},
 			"results": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -39,8 +44,12 @@ func dataSourceIpamsvcFixedAddressRead(ctx context.Context, d *schema.ResourceDa
 	filtersMap := d.Get("filters").(map[string]interface{})
 	filterStr := filterFromMap(filtersMap)
 
+	tfiltersMap := d.Get("tfilters").(map[string]interface{})
+	tfilterStr := filterFromMap(tfiltersMap)
+
 	resp, err := c.IPAddressManagementAPI.FixedAddress.FixedAddressList(&fixed_address.FixedAddressListParams{
 		Filter:  swag.String(filterStr),
+		Tfilter: swag.String(tfilterStr),
 		Context: ctx,
 	}, nil)
 	if err != nil {

--- a/b1ddi/data_source_ipam_fixed_address_test.go
+++ b/b1ddi/data_source_ipam_fixed_address_test.go
@@ -19,18 +19,11 @@ func TestAccDataSourceIpamsvcFixedAddress_Basic(t *testing.T) {
 							"name" = "tf_acc_test_fixed_address"
 						}
 					}
-					data "b1ddi_fixed_addresses" "tf_acc_fixed_addresses_by_tag" {
-						tfilters = {
-							# Search by Tag
-							"TestType" = "Acceptance"
-						}
-					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.comment", "This Fixed Address is created by terraform provider acceptance test"),
-					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},
 		},
@@ -50,11 +43,20 @@ func TestAccDataSourceIpamsvcFixedAddress_FullConfig(t *testing.T) {
 							"name" = "tf_acc_test_fixed_address_full_config"
 						}
 					}
+					data "b1ddi_fixed_addresses" "tf_acc_fixed_addresses_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.comment", "This Fixed Address is created by terraform provider acceptance test"),
+					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses_by_tag", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses_by_tag", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses_by_tag", "results.0.tags.TestType", "Acceptance"),
 				),
 			},
 		},

--- a/b1ddi/data_source_ipam_fixed_address_test.go
+++ b/b1ddi/data_source_ipam_fixed_address_test.go
@@ -26,6 +26,19 @@ func TestAccDataSourceIpamsvcFixedAddress_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.comment", "This Fixed Address is created by terraform provider acceptance test"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+					data "b1ddi_fixed_addresses" "tf_acc_fixed_addresses_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses_by_tag", "tfilters.TestType", "Acceptance"),
+				),
+			},
 		},
 	})
 }

--- a/b1ddi/data_source_ipam_fixed_address_test.go
+++ b/b1ddi/data_source_ipam_fixed_address_test.go
@@ -19,15 +19,6 @@ func TestAccDataSourceIpamsvcFixedAddress_Basic(t *testing.T) {
 							"name" = "tf_acc_test_fixed_address"
 						}
 					}
-				`),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.#", "1"),
-					resource.TestCheckResourceAttrSet("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.id"),
-					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.comment", "This Fixed Address is created by terraform provider acceptance test"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
 					data "b1ddi_fixed_addresses" "tf_acc_fixed_addresses_by_tag" {
 						tfilters = {
 							# Search by Tag
@@ -36,6 +27,9 @@ func TestAccDataSourceIpamsvcFixedAddress_Basic(t *testing.T) {
 					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses", "results.0.comment", "This Fixed Address is created by terraform provider acceptance test"),
 					resource.TestCheckResourceAttr("data.b1ddi_fixed_addresses.tf_acc_fixed_addresses_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},

--- a/b1ddi/data_source_ipam_ip_space.go
+++ b/b1ddi/data_source_ipam_ip_space.go
@@ -21,6 +21,11 @@ func dataSourceIpamsvcIPSpace() *schema.Resource {
 				Optional:    true,
 				Description: "Configure a map of filters to be applied on the search result.",
 			},
+			"tfilters": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Configure a map tag filters to be applied on the search result.",
+			},
 			"results": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -39,8 +44,12 @@ func dataSourceIpamsvcIPSpaceRead(ctx context.Context, d *schema.ResourceData, m
 	filtersMap := d.Get("filters").(map[string]interface{})
 	filterStr := filterFromMap(filtersMap)
 
+	tfiltersMap := d.Get("tfilters").(map[string]interface{})
+	tfilterStr := filterFromMap(tfiltersMap)
+
 	resp, err := c.IPAddressManagementAPI.IPSpace.IPSpaceList(&ip_space.IPSpaceListParams{
 		Filter:  swag.String(filterStr),
+		Tfilter: swag.String(tfilterStr),
 		Context: ctx,
 	}, nil)
 	if err != nil {

--- a/b1ddi/data_source_ipam_ip_space_test.go
+++ b/b1ddi/data_source_ipam_ip_space_test.go
@@ -25,12 +25,25 @@ func TestAccDataSourceIpamsvcIPSpace_Basic(t *testing.T) {
 							# Check bool filter
 							"hostname_rewrite_enabled" = false
 						}
-					}
+                    }
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.comment", "This IP Space is created by terraform provider acceptance test"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+					data "b1ddi_ip_spaces" "tf_acc_spaces_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},
 		},
@@ -56,6 +69,7 @@ func TestAccDataSourceIpamsvcIPSpace_FullConfig(t *testing.T) {
 							# Check bool filter
 							"hostname_rewrite_enabled" = true
 						}
+
 					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/b1ddi/data_source_ipam_ip_space_test.go
+++ b/b1ddi/data_source_ipam_ip_space_test.go
@@ -26,18 +26,11 @@ func TestAccDataSourceIpamsvcIPSpace_Basic(t *testing.T) {
 							"hostname_rewrite_enabled" = false
 						}
 					}
-					data "b1ddi_ip_spaces" "tf_acc_spaces_by_tag" {
-						tfilters = {
-							# Search by Tag
-							"TestType" = "Acceptance"
-						}
-					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.comment", "This IP Space is created by terraform provider acceptance test"),
-					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},
 		},
@@ -65,11 +58,20 @@ func TestAccDataSourceIpamsvcIPSpace_FullConfig(t *testing.T) {
 						}
 
 					}
+					data "b1ddi_ip_spaces" "tf_acc_spaces_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.comment", "This IP Space is created by terraform provider acceptance test"),
+					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces_by_tag", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_ip_spaces.tf_acc_spaces_by_tag", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces_by_tag", "results.0.tags.TestType", "Acceptance"),
 				),
 			},
 		},

--- a/b1ddi/data_source_ipam_ip_space_test.go
+++ b/b1ddi/data_source_ipam_ip_space_test.go
@@ -26,15 +26,6 @@ func TestAccDataSourceIpamsvcIPSpace_Basic(t *testing.T) {
 							"hostname_rewrite_enabled" = false
 						}
 					}
-				`),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.#", "1"),
-					resource.TestCheckResourceAttrSet("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.id"),
-					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.comment", "This IP Space is created by terraform provider acceptance test"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
 					data "b1ddi_ip_spaces" "tf_acc_spaces_by_tag" {
 						tfilters = {
 							# Search by Tag
@@ -43,6 +34,9 @@ func TestAccDataSourceIpamsvcIPSpace_Basic(t *testing.T) {
 					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.0.comment", "This IP Space is created by terraform provider acceptance test"),
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},

--- a/b1ddi/data_source_ipam_ip_space_test.go
+++ b/b1ddi/data_source_ipam_ip_space_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceIpamsvcIPSpace_Basic(t *testing.T) {
 							# Check bool filter
 							"hostname_rewrite_enabled" = false
 						}
-                    }
+					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_ip_spaces.tf_acc_spaces", "results.#", "1"),

--- a/b1ddi/data_source_ipam_range.go
+++ b/b1ddi/data_source_ipam_range.go
@@ -21,6 +21,11 @@ func dataSourceIpamsvcRange() *schema.Resource {
 				Optional:    true,
 				Description: "Configure a map of filters to be applied on the search result.",
 			},
+			"tfilters": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Configure a map of tag filters to be applied on the search result.",
+			},
 			"results": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -39,8 +44,12 @@ func dataSourceIpamsvcRangeRead(ctx context.Context, d *schema.ResourceData, m i
 	filtersMap := d.Get("filters").(map[string]interface{})
 	filterStr := filterFromMap(filtersMap)
 
+	tfiltersMap := d.Get("tfilters").(map[string]interface{})
+	tfilterStr := filterFromMap(tfiltersMap)
+
 	resp, err := c.IPAddressManagementAPI.RangeOperations.RangeList(&range_operations.RangeListParams{
 		Filter:  swag.String(filterStr),
+		Tfilter: swag.String(tfilterStr),
 		Context: ctx,
 	}, nil)
 	if err != nil {

--- a/b1ddi/data_source_ipam_range_test.go
+++ b/b1ddi/data_source_ipam_range_test.go
@@ -22,18 +22,11 @@ func TestAccDataSourceIpamsvcRange_Basic(t *testing.T) {
 							"end" = "192.168.1.30"
 						}
 					}
-					data "b1ddi_ranges" "tf_acc_ranges_by_tag" {
-						tfilters = {
-							# Search by Tag
-							"TestType" = "Acceptance"
-						}
-					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_ranges.tf_acc_ranges", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.0.comment", "This Range is created by terraform provider acceptance test"),
-					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},
 		},
@@ -56,11 +49,20 @@ func TestAccDataSourceIpamsvcRange_FullConfig(t *testing.T) {
 							"end" = "192.168.1.30"
 						}
 					}
+					data "b1ddi_ranges" "tf_acc_ranges_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_ranges.tf_acc_ranges", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.0.comment", "This Range is created by terraform provider acceptance test"),
+					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges_by_tag", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_ranges.tf_acc_ranges_by_tag", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges_by_tag", "results.0.tags.TestType", "Acceptance"),
 				),
 			},
 		},

--- a/b1ddi/data_source_ipam_range_test.go
+++ b/b1ddi/data_source_ipam_range_test.go
@@ -22,15 +22,6 @@ func TestAccDataSourceIpamsvcRange_Basic(t *testing.T) {
 							"end" = "192.168.1.30"
 						}
 					}
-				`),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.#", "1"),
-					resource.TestCheckResourceAttrSet("data.b1ddi_ranges.tf_acc_ranges", "results.0.id"),
-					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.0.comment", "This Range is created by terraform provider acceptance test"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
 					data "b1ddi_ranges" "tf_acc_ranges_by_tag" {
 						tfilters = {
 							# Search by Tag
@@ -39,6 +30,9 @@ func TestAccDataSourceIpamsvcRange_Basic(t *testing.T) {
 					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_ranges.tf_acc_ranges", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.0.comment", "This Range is created by terraform provider acceptance test"),
 					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},

--- a/b1ddi/data_source_ipam_range_test.go
+++ b/b1ddi/data_source_ipam_range_test.go
@@ -29,6 +29,19 @@ func TestAccDataSourceIpamsvcRange_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges", "results.0.comment", "This Range is created by terraform provider acceptance test"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+					data "b1ddi_ranges" "tf_acc_ranges_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_ranges.tf_acc_ranges_by_tag", "tfilters.TestType", "Acceptance"),
+				),
+			},
 		},
 	})
 }

--- a/b1ddi/data_source_ipam_subnet.go
+++ b/b1ddi/data_source_ipam_subnet.go
@@ -21,6 +21,11 @@ func dataSourceIpamsvcSubnet() *schema.Resource {
 				Optional:    true,
 				Description: "Configure a map of filters to be applied on the search result.",
 			},
+			"tfilters": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Configure a map of tag filters to be applied on the search result.",
+			},
 			"results": {
 				Type:        schema.TypeList,
 				Computed:    true,
@@ -39,8 +44,12 @@ func dataSourceIpamsvcSubnetRead(ctx context.Context, d *schema.ResourceData, m 
 	filtersMap := d.Get("filters").(map[string]interface{})
 	filterStr := filterFromMap(filtersMap)
 
+	tfiltersMap := d.Get("tfilters").(map[string]interface{})
+	tfilterStr := filterFromMap(tfiltersMap)
+
 	resp, err := c.IPAddressManagementAPI.Subnet.SubnetList(&subnet.SubnetListParams{
 		Filter:  swag.String(filterStr),
+		Tfilter: swag.String(tfilterStr),
 		Context: ctx,
 	}, nil)
 	if err != nil {

--- a/b1ddi/data_source_ipam_subnet_test.go
+++ b/b1ddi/data_source_ipam_subnet_test.go
@@ -24,18 +24,11 @@ func TestAccDataSourceIpamsvcSubnet_Basic(t *testing.T) {
 							"cidr" = 24
 						}
 					}
-					data "b1ddi_subnets" "tf_acc_subnets_by_tag" {
-						tfilters = {
-							# Search by Tag
-							"TestType" = "Acceptance"
-						}
-					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_subnets.tf_acc_subnets", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.0.comment", "This Subnet is created by terraform provider acceptance test"),
-					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},
 		},
@@ -60,11 +53,20 @@ func TestAccDataSourceIpamsvcSubnet_FullConfig(t *testing.T) {
 							"cidr" = 24
 						}
 					}
+				    data "b1ddi_subnets" "tf_acc_subnets_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.#", "1"),
 					resource.TestCheckResourceAttrSet("data.b1ddi_subnets.tf_acc_subnets", "results.0.id"),
 					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.0.comment", "This Subnet is created by terraform provider acceptance test"),
+					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets_by_tag", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_subnets.tf_acc_subnets_by_tag", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets_by_tag", "results.0.tags.TestType", "Acceptance"),
 				),
 			},
 		},

--- a/b1ddi/data_source_ipam_subnet_test.go
+++ b/b1ddi/data_source_ipam_subnet_test.go
@@ -31,6 +31,19 @@ func TestAccDataSourceIpamsvcSubnet_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.0.comment", "This Subnet is created by terraform provider acceptance test"),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+					data "b1ddi_subnets" "tf_acc_subnets_by_tag" {
+						tfilters = {
+							# Search by Tag
+							"TestType" = "Acceptance"
+						}
+					}
+				`),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets_by_tag", "tfilters.TestType", "Acceptance"),
+				),
+			},
 		},
 	})
 }

--- a/b1ddi/data_source_ipam_subnet_test.go
+++ b/b1ddi/data_source_ipam_subnet_test.go
@@ -24,15 +24,6 @@ func TestAccDataSourceIpamsvcSubnet_Basic(t *testing.T) {
 							"cidr" = 24
 						}
 					}
-				`),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.#", "1"),
-					resource.TestCheckResourceAttrSet("data.b1ddi_subnets.tf_acc_subnets", "results.0.id"),
-					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.0.comment", "This Subnet is created by terraform provider acceptance test"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(`
 					data "b1ddi_subnets" "tf_acc_subnets_by_tag" {
 						tfilters = {
 							# Search by Tag
@@ -41,6 +32,9 @@ func TestAccDataSourceIpamsvcSubnet_Basic(t *testing.T) {
 					}
 				`),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.#", "1"),
+					resource.TestCheckResourceAttrSet("data.b1ddi_subnets.tf_acc_subnets", "results.0.id"),
+					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets", "results.0.comment", "This Subnet is created by terraform provider acceptance test"),
 					resource.TestCheckResourceAttr("data.b1ddi_subnets.tf_acc_subnets_by_tag", "tfilters.TestType", "Acceptance"),
 				),
 			},

--- a/examples/data-sources/b1ddi_address_blocks/data-source.tf
+++ b/examples/data-sources/b1ddi_address_blocks/data-source.tf
@@ -18,4 +18,9 @@ data "b1ddi_address_blocks" "address_block_by_addr" {
 # Get all Address Blocks
 data "b1ddi_address_blocks" "all_address_blocks" {}
 
-
+# Get Address Block by tag
+data "b1ddi_address_blocks" "address_block_by_tag" {
+  tfilters = {
+    location  = "site1"
+  }
+}

--- a/examples/data-sources/b1ddi_fixed_addresses/data-source.tf
+++ b/examples/data-sources/b1ddi_fixed_addresses/data-source.tf
@@ -16,3 +16,10 @@ data "b1ddi_fixed_addresses" "tf_example_fixed_address" {
 
 # Get all Fixed Addresses
 data "b1ddi_fixed_addresses" "all_fixed_addresses" {}
+
+# Get Fixed Address by tag
+data "b1ddi_fixed_addresses" "fixed_address_by_tag"{
+  tfilters = {
+    location = "site1"
+  }
+}

--- a/examples/data-sources/b1ddi_ip_spaces/data-source.tf
+++ b/examples/data-sources/b1ddi_ip_spaces/data-source.tf
@@ -16,3 +16,10 @@ data "b1ddi_ip_spaces" "example_tf_space" {
 
 # Get all IP Spaces
 data "b1ddi_ip_spaces" "all_ip_spaces" {}
+
+# Get IP Space by tag
+data "b1ddi_ip_spaces" "ip_space_by_tag" {
+  tfilters = {
+    location  = "site1"
+  }
+}

--- a/examples/data-sources/b1ddi_ranges/data-source.tf
+++ b/examples/data-sources/b1ddi_ranges/data-source.tf
@@ -24,3 +24,10 @@ data "b1ddi_ranges" "range_by_name" {
     "name" = "example_tf_range"
   }
 }
+
+# Get Range by tag
+data "b1ddi_ranges" "range_by_tag"{
+  tfilter = {
+    location = "site1"
+  }
+}

--- a/examples/data-sources/b1ddi_subnets/data-source.tf
+++ b/examples/data-sources/b1ddi_subnets/data-source.tf
@@ -16,3 +16,10 @@ data "b1ddi_subnets" "example_tf_subnet" {
 
 # Get all Subnets
 data "b1ddi_subnets" "all_subnets" {}
+
+# Get Subnet by tag
+data "b1ddi_subnets" "subnet_by_tag"{
+  tfilter = {
+    location = "site1"
+  }
+}

--- a/examples/resources/b1ddi_address_block/resource.tf
+++ b/examples/resources/b1ddi_address_block/resource.tf
@@ -9,6 +9,9 @@ terraform {
 
 resource "b1ddi_ip_space" "tf_example_space" {
   name = "tf_example_space"
+//  tags = {
+//    location   = "site1"
+//  }
 }
 
 resource "b1ddi_address_block" "tf_example_address_block" {

--- a/examples/resources/b1ddi_address_block/resource.tf
+++ b/examples/resources/b1ddi_address_block/resource.tf
@@ -9,9 +9,9 @@ terraform {
 
 resource "b1ddi_ip_space" "tf_example_space" {
   name = "tf_example_space"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }
 
 resource "b1ddi_address_block" "tf_example_address_block" {

--- a/examples/resources/b1ddi_fixed_address/resource.tf
+++ b/examples/resources/b1ddi_fixed_address/resource.tf
@@ -10,6 +10,9 @@ terraform {
 resource "b1ddi_ip_space" "tf_example_space" {
   name    = "tf_example_space"
   comment = "This is the example IP Space created by the B1DDI terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
 }
 
 resource "b1ddi_subnet" "tf_example_subnet" {
@@ -17,6 +20,9 @@ resource "b1ddi_subnet" "tf_example_subnet" {
   address = "192.168.1.0"
   cidr    = 24
   space   = b1ddi_ip_space.tf_example_space.id
+//  tags = {
+//    location   = "site1"
+//  }
 }
 
 resource "b1ddi_fixed_address" "tf_example_fixed_address" {
@@ -26,5 +32,8 @@ resource "b1ddi_fixed_address" "tf_example_fixed_address" {
   match_type  = "mac"
   match_value = "00:00:00:00:00:00"
   comment     = "This is the example Fixed Address created by the B1DDI terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
   depends_on  = [b1ddi_subnet.tf_example_subnet]
 }

--- a/examples/resources/b1ddi_fixed_address/resource.tf
+++ b/examples/resources/b1ddi_fixed_address/resource.tf
@@ -10,9 +10,9 @@ terraform {
 resource "b1ddi_ip_space" "tf_example_space" {
   name    = "tf_example_space"
   comment = "This is the example IP Space created by the B1DDI terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }
 
 resource "b1ddi_subnet" "tf_example_subnet" {
@@ -20,9 +20,9 @@ resource "b1ddi_subnet" "tf_example_subnet" {
   address = "192.168.1.0"
   cidr    = 24
   space   = b1ddi_ip_space.tf_example_space.id
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }
 
 resource "b1ddi_fixed_address" "tf_example_fixed_address" {
@@ -32,8 +32,8 @@ resource "b1ddi_fixed_address" "tf_example_fixed_address" {
   match_type  = "mac"
   match_value = "00:00:00:00:00:00"
   comment     = "This is the example Fixed Address created by the B1DDI terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
   depends_on  = [b1ddi_subnet.tf_example_subnet]
 }

--- a/examples/resources/b1ddi_ip_space/resource.tf
+++ b/examples/resources/b1ddi_ip_space/resource.tf
@@ -10,4 +10,7 @@ terraform {
 resource "b1ddi_ip_space" "example_tf_space" {
   name = "example_tf_space"
   comment = "Example IP space create by the terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
 }

--- a/examples/resources/b1ddi_ip_space/resource.tf
+++ b/examples/resources/b1ddi_ip_space/resource.tf
@@ -10,7 +10,7 @@ terraform {
 resource "b1ddi_ip_space" "example_tf_space" {
   name = "example_tf_space"
   comment = "Example IP space create by the terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }

--- a/examples/resources/b1ddi_range/resource.tf
+++ b/examples/resources/b1ddi_range/resource.tf
@@ -10,9 +10,9 @@ terraform {
 resource "b1ddi_ip_space" "example_tf_space" {
   name = "example_tf_space"
   comment = "Example IP space created by the terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }
 
 resource "b1ddi_subnet" "example_tf_subnet" {
@@ -21,9 +21,9 @@ resource "b1ddi_subnet" "example_tf_subnet" {
   address = "192.168.1.0"
   cidr = 24
   comment = "Example Subnet created by the terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }
 
 resource "b1ddi_range" "tf_acc_test_range" {
@@ -32,8 +32,8 @@ resource "b1ddi_range" "tf_acc_test_range" {
   name = "example_tf_range"
   space = b1ddi_ip_space.example_tf_space.id
   comment = "Example Range created by the terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
   depends_on = [b1ddi_subnet.example_tf_subnet]
 }

--- a/examples/resources/b1ddi_range/resource.tf
+++ b/examples/resources/b1ddi_range/resource.tf
@@ -10,6 +10,9 @@ terraform {
 resource "b1ddi_ip_space" "example_tf_space" {
   name = "example_tf_space"
   comment = "Example IP space created by the terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
 }
 
 resource "b1ddi_subnet" "example_tf_subnet" {
@@ -18,6 +21,9 @@ resource "b1ddi_subnet" "example_tf_subnet" {
   address = "192.168.1.0"
   cidr = 24
   comment = "Example Subnet created by the terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
 }
 
 resource "b1ddi_range" "tf_acc_test_range" {
@@ -26,5 +32,8 @@ resource "b1ddi_range" "tf_acc_test_range" {
   name = "example_tf_range"
   space = b1ddi_ip_space.example_tf_space.id
   comment = "Example Range created by the terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
   depends_on = [b1ddi_subnet.example_tf_subnet]
 }

--- a/examples/resources/b1ddi_subnet/resource.tf
+++ b/examples/resources/b1ddi_subnet/resource.tf
@@ -10,9 +10,9 @@ terraform {
 resource "b1ddi_ip_space" "example_tf_space" {
   name = "example_tf_space"
   comment = "Example IP space for the terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }
 
 resource "b1ddi_subnet" "example_tf_subnet" {
@@ -21,7 +21,7 @@ resource "b1ddi_subnet" "example_tf_subnet" {
   address = "192.168.1.0"
   cidr = 24
   comment = "Example Subnet created by the terraform provider"
-//  tags = {
-//    location   = "site1"
-//  }
+  tags = {
+    location   = "site1"
+  }
 }

--- a/examples/resources/b1ddi_subnet/resource.tf
+++ b/examples/resources/b1ddi_subnet/resource.tf
@@ -10,6 +10,9 @@ terraform {
 resource "b1ddi_ip_space" "example_tf_space" {
   name = "example_tf_space"
   comment = "Example IP space for the terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
 }
 
 resource "b1ddi_subnet" "example_tf_subnet" {
@@ -18,4 +21,7 @@ resource "b1ddi_subnet" "example_tf_subnet" {
   address = "192.168.1.0"
   cidr = 24
   comment = "Example Subnet created by the terraform provider"
+//  tags = {
+//    location   = "site1"
+//  }
 }


### PR DESCRIPTION
# Issue/Feature description

* Adding tags support for IPAM/DHCP objects ( IPSpace, Address Block, Subnet, Range, Fixed Address )

# How it was fixed/implemented

* Added TFilter ( tag ) filter to IPAM objects 

# Tests

* Added unit test for tags support 
* All units test related to IPAM passed. 

> === RUN   TestAccDataSourceIpamsvcAddressBlock_Basic
--- PASS: TestAccDataSourceIpamsvcAddressBlock_Basic (24.38s)
=== RUN   TestAccDataSourceIpamsvcAddressBlock_FullConfig
--- PASS: TestAccDataSourceIpamsvcAddressBlock_FullConfig (14.81s)
=== RUN   TestAccDataSourceIpamsvcAddress
--- PASS: TestAccDataSourceIpamsvcAddress (6.34s)
=== RUN   TestAccDataSourceIpamsvcDhcpHost
--- PASS: TestAccDataSourceIpamsvcDhcpHost (6.55s)
=== RUN   TestAccDataSourceIpamsvcDhcpHostByName
--- PASS: TestAccDataSourceIpamsvcDhcpHostByName (6.57s)
=== RUN   TestAccDataSourceIpamsvcFixedAddress_Basic
--- PASS: TestAccDataSourceIpamsvcFixedAddress_Basic (11.94s)
=== RUN   TestAccDataSourceIpamsvcFixedAddress_FullConfig
--- PASS: TestAccDataSourceIpamsvcFixedAddress_FullConfig (8.48s)
=== RUN   TestAccDataSourceIpamsvcIPSpace_Basic
--- PASS: TestAccDataSourceIpamsvcIPSpace_Basic (13.19s)
=== RUN   TestAccDataSourceIpamsvcIPSpace_FullConfig
--- PASS: TestAccDataSourceIpamsvcIPSpace_FullConfig (18.78s)
=== RUN   TestAccDataSourceIpamsvcOptionCode
--- PASS: TestAccDataSourceIpamsvcOptionCode (2.14s)
=== RUN   TestAccDataSourceIpamsvcRange_Basic
--- PASS: TestAccDataSourceIpamsvcRange_Basic (31.02s)
=== RUN   TestAccDataSourceIpamsvcRange_FullConfig
--- PASS: TestAccDataSourceIpamsvcRange_FullConfig (10.10s)
=== RUN   TestAccDataSourceIpamsvcSubnet_Basic
--- PASS: TestAccDataSourceIpamsvcSubnet_Basic (13.95s)
=== RUN   TestAccDataSourceIpamsvcSubnet_FullConfig
--- PASS: TestAccDataSourceIpamsvcSubnet_FullConfig (19.17s)
=== RUN   TestFlattenIpamsvcAsmEnableBlock
=== RUN   TestFlattenIpamsvcAsmEnableBlock/NilInput
=== RUN   TestFlattenIpamsvcAsmEnableBlock/FullInput
--- PASS: TestFlattenIpamsvcAsmEnableBlock (0.00s)
    --- PASS: TestFlattenIpamsvcAsmEnableBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcAsmEnableBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcAsmEnableBlock
=== RUN   TestExpandIpamsvcAsmEnableBlock/NilInput
=== RUN   TestExpandIpamsvcAsmEnableBlock/FullInput
=== RUN   TestExpandIpamsvcAsmEnableBlock/IncorrectReenableDate_ExpectError
--- PASS: TestExpandIpamsvcAsmEnableBlock (0.00s)
    --- PASS: TestExpandIpamsvcAsmEnableBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcAsmEnableBlock/FullInput (0.00s)
    --- PASS: TestExpandIpamsvcAsmEnableBlock/IncorrectReenableDate_ExpectError (0.00s)
=== RUN   TestFlattenIpamsvcAsmGrowthBlock
=== RUN   TestFlattenIpamsvcAsmGrowthBlock/NilInput
=== RUN   TestFlattenIpamsvcAsmGrowthBlock/FullInput
--- PASS: TestFlattenIpamsvcAsmGrowthBlock (0.00s)
    --- PASS: TestFlattenIpamsvcAsmGrowthBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcAsmGrowthBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcAsmGrowthBlock
=== RUN   TestExpandIpamsvcAsmGrowthBlock/NilInput
=== RUN   TestExpandIpamsvcAsmGrowthBlock/FullInput
--- PASS: TestExpandIpamsvcAsmGrowthBlock (0.00s)
    --- PASS: TestExpandIpamsvcAsmGrowthBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcAsmGrowthBlock/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcDDNSHostnameBlock
=== RUN   TestFlattenIpamsvcDDNSHostnameBlock/NilInput
=== RUN   TestFlattenIpamsvcDDNSHostnameBlock/FullInput
--- PASS: TestFlattenIpamsvcDDNSHostnameBlock (0.00s)
    --- PASS: TestFlattenIpamsvcDDNSHostnameBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcDDNSHostnameBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcDDNSHostnameBlock
=== RUN   TestExpandIpamsvcDDNSHostnameBlock/NilInput
=== RUN   TestExpandIpamsvcDDNSHostnameBlock/FullInput
--- PASS: TestExpandIpamsvcDDNSHostnameBlock (0.00s)
    --- PASS: TestExpandIpamsvcDDNSHostnameBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcDDNSHostnameBlock/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcDDNSUpdateBlock
=== RUN   TestFlattenIpamsvcDDNSUpdateBlock/NilInput
=== RUN   TestFlattenIpamsvcDDNSUpdateBlock/FullInput
--- PASS: TestFlattenIpamsvcDDNSUpdateBlock (0.00s)
    --- PASS: TestFlattenIpamsvcDDNSUpdateBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcDDNSUpdateBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcDDNSUpdateBlock
=== RUN   TestExpandIpamsvcDDNSUpdateBlock/NilInput
=== RUN   TestExpandIpamsvcDDNSUpdateBlock/FullInput
--- PASS: TestExpandIpamsvcDDNSUpdateBlock (0.00s)
    --- PASS: TestExpandIpamsvcDDNSUpdateBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcDDNSUpdateBlock/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcHostnameRewriteBlock
=== RUN   TestFlattenIpamsvcHostnameRewriteBlock/FullInput
=== RUN   TestFlattenIpamsvcHostnameRewriteBlock/NilInput
--- PASS: TestFlattenIpamsvcHostnameRewriteBlock (0.00s)
    --- PASS: TestFlattenIpamsvcHostnameRewriteBlock/FullInput (0.00s)
    --- PASS: TestFlattenIpamsvcHostnameRewriteBlock/NilInput (0.00s)
=== RUN   TestExpandIpamsvcHostnameRewriteBlock
=== RUN   TestExpandIpamsvcHostnameRewriteBlock/NilInput
=== RUN   TestExpandIpamsvcHostnameRewriteBlock/FullInput
--- PASS: TestExpandIpamsvcHostnameRewriteBlock (0.00s)
    --- PASS: TestExpandIpamsvcHostnameRewriteBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcHostnameRewriteBlock/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcInheritedASMConfig
=== RUN   TestFlattenIpamsvcInheritedASMConfig/FullInput
=== RUN   TestFlattenIpamsvcInheritedASMConfig/NilInput
--- PASS: TestFlattenIpamsvcInheritedASMConfig (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedASMConfig/FullInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedASMConfig/NilInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedASMConfig
=== RUN   TestExpandIpamsvcInheritedASMConfig/NilInput
=== RUN   TestExpandIpamsvcInheritedASMConfig/FullInput
=== RUN   TestExpandIpamsvcInheritedASMConfig/IncorrectAsmEnableBlock.Value.ReenableDate_ExpectError
--- PASS: TestExpandIpamsvcInheritedASMConfig (0.00s)
    --- PASS: TestExpandIpamsvcInheritedASMConfig/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedASMConfig/FullInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedASMConfig/IncorrectAsmEnableBlock.Value.ReenableDate_ExpectError (0.00s)
=== RUN   TestFlattenIpamsvcInheritedAsmEnableBlock
=== RUN   TestFlattenIpamsvcInheritedAsmEnableBlock/NilInput
=== RUN   TestFlattenIpamsvcInheritedAsmEnableBlock/FullInput
--- PASS: TestFlattenIpamsvcInheritedAsmEnableBlock (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedAsmEnableBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedAsmEnableBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedAsmEnableBlock
=== RUN   TestExpandIpamsvcInheritedAsmEnableBlock/NilInput
=== RUN   TestExpandIpamsvcInheritedAsmEnableBlock/FullInput
=== RUN   TestExpandIpamsvcInheritedAsmEnableBlock/IncorrectReenableDate_ExpectError
--- PASS: TestExpandIpamsvcInheritedAsmEnableBlock (0.00s)
    --- PASS: TestExpandIpamsvcInheritedAsmEnableBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedAsmEnableBlock/FullInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedAsmEnableBlock/IncorrectReenableDate_ExpectError (0.00s)
=== RUN   TestFlattenIpamsvcInheritedAsmGrowthBlock
=== RUN   TestFlattenIpamsvcInheritedAsmGrowthBlock/NilInput
=== RUN   TestFlattenIpamsvcInheritedAsmGrowthBlock/FullInput
--- PASS: TestFlattenIpamsvcInheritedAsmGrowthBlock (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedAsmGrowthBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedAsmGrowthBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedAsmGrowthBlock
=== RUN   TestExpandIpamsvcInheritedAsmGrowthBlock/NilInput
=== RUN   TestExpandIpamsvcInheritedAsmGrowthBlock/FullInput
--- PASS: TestExpandIpamsvcInheritedAsmGrowthBlock (0.00s)
    --- PASS: TestExpandIpamsvcInheritedAsmGrowthBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedAsmGrowthBlock/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcInheritedDDNSHostnameBlock
=== RUN   TestFlattenIpamsvcInheritedDDNSHostnameBlock/NilInput
=== RUN   TestFlattenIpamsvcInheritedDDNSHostnameBlock/FullInput
--- PASS: TestFlattenIpamsvcInheritedDDNSHostnameBlock (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDDNSHostnameBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDDNSHostnameBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedDDNSHostnameBlock
=== RUN   TestExpandIpamsvcInheritedDDNSHostnameBlock/NilInput
=== RUN   TestExpandIpamsvcInheritedDDNSHostnameBlock/FullInput
--- PASS: TestExpandIpamsvcInheritedDDNSHostnameBlock (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDDNSHostnameBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDDNSHostnameBlock/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcInheritedDDNSUpdateBlock
=== RUN   TestFlattenIpamsvcInheritedDDNSUpdateBlock/NilInput
=== RUN   TestFlattenIpamsvcInheritedDDNSUpdateBlock/FullInput
--- PASS: TestFlattenIpamsvcInheritedDDNSUpdateBlock (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDDNSUpdateBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDDNSUpdateBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedDDNSUpdateBlock
=== RUN   TestExpandIpamsvcInheritedDDNSUpdateBlock/NilInput
=== RUN   TestExpandIpamsvcInheritedDDNSUpdateBlock/FullInput
--- PASS: TestExpandIpamsvcInheritedDDNSUpdateBlock (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDDNSUpdateBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDDNSUpdateBlock/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcInheritedDHCPConfig
=== RUN   TestFlattenIpamsvcInheritedDHCPConfig/NilInput
=== RUN   TestFlattenIpamsvcInheritedDHCPConfig/FullInput
--- PASS: TestFlattenIpamsvcInheritedDHCPConfig (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDHCPConfig/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDHCPConfig/FullInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedDHCPConfig
=== RUN   TestExpandIpamsvcInheritedDHCPConfig/FullInput
=== RUN   TestExpandIpamsvcInheritedDHCPConfig/NilInput
--- PASS: TestExpandIpamsvcInheritedDHCPConfig (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDHCPConfig/FullInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDHCPConfig/NilInput (0.00s)
=== RUN   TestFlattenIpamsvcInheritedDHCPOptionList
=== RUN   TestFlattenIpamsvcInheritedDHCPOptionList/NilInput
=== RUN   TestFlattenIpamsvcInheritedDHCPOptionList/FullInput
--- PASS: TestFlattenIpamsvcInheritedDHCPOptionList (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDHCPOptionList/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedDHCPOptionList/FullInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedDHCPOptionList
=== RUN   TestExpandIpamsvcInheritedDHCPOptionList/NilInput
=== RUN   TestExpandIpamsvcInheritedDHCPOptionList/FullInput
--- PASS: TestExpandIpamsvcInheritedDHCPOptionList (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDHCPOptionList/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedDHCPOptionList/FullInput (0.00s)
=== RUN   TestFlattenIpamsvcInheritedHostnameRewriteBlock
=== RUN   TestFlattenIpamsvcInheritedHostnameRewriteBlock/NilInput
=== RUN   TestFlattenIpamsvcInheritedHostnameRewriteBlock/FullInput
--- PASS: TestFlattenIpamsvcInheritedHostnameRewriteBlock (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedHostnameRewriteBlock/NilInput (0.00s)
    --- PASS: TestFlattenIpamsvcInheritedHostnameRewriteBlock/FullInput (0.00s)
=== RUN   TestExpandIpamsvcInheritedHostnameRewriteBlock
=== RUN   TestExpandIpamsvcInheritedHostnameRewriteBlock/NilInput
=== RUN   TestExpandIpamsvcInheritedHostnameRewriteBlock/FullInput
--- PASS: TestExpandIpamsvcInheritedHostnameRewriteBlock (0.00s)
    --- PASS: TestExpandIpamsvcInheritedHostnameRewriteBlock/NilInput (0.00s)
    --- PASS: TestExpandIpamsvcInheritedHostnameRewriteBlock/FullInput (0.00s)
PASS
ok      terraform-provider-b1ddi/b1ddi  187.903s

# Reviewers
